### PR TITLE
Fix references to FHIRPath specification sections in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ Completed sections:
 - 6.5 (Boolean logic)
 - 6.6 (Math)
 - 6.8 (Operator Precedence) - handled by ANTLR parser
-- 7   (Lexical Elements) - handled by ANTLR parser
-- 8   (Environment Variables)
+- 8   (Lexical Elements) - handled by ANTLR parser
+- 9   (Environment Variables)
 
 We are deferring handling information about FHIR resources, as much as
 possible, with the exception of support for choice types.  This affects


### PR DESCRIPTION
Fixing the reference for fhirpath sections in Readme to match the specs document http://hl7.org/fhirpath/#environment-variables

```
7. Aggregates
8. Lexical Elements
9. Environment variables
```