### PR TITLE
Fix hash for null values #138

### DIFF
--- a/src/hash-object.js
+++ b/src/hash-object.js
@@ -24,8 +24,9 @@ function hashObject(obj) {
  */
 function prepareObject(value) {
   value = valDataConverted(value);
-
-  if (typeof value === 'number') {
+  if (value === null) {
+    return null;
+  } else if (typeof value === 'number') {
     return roundToMaxPrecision(value);
   } else if (value instanceof Date) {
     return value.toISOString();


### PR DESCRIPTION
Hello! 

This PR fixes `hashObject` for null values. 
Previously it worked in a wrong way because it relied on the check `typeof value === 'object'`, which executes as true even if `value` is `null`. 

For details see #138