### PR TITLE
implement hasValue method

### DIFF
--- a/bin/fhirpath
+++ b/bin/fhirpath
@@ -16,10 +16,8 @@ options.parse(process.argv);
 // this cli util is part of public interface of fhirpath
 // it can be extended with understading urls and files
 // TODO: introduce subcommands to inspect, eval fhirpath etc
-
 const expression =  options.expression;
 const base =  options.basePath;
-
 if (!expression)
   options.help();
 else {

--- a/src/fhirpath.js
+++ b/src/fhirpath.js
@@ -106,6 +106,7 @@ engine.invocationTable = {
   toTime:       {fn: misc.toTime},
   toBoolean:    {fn: misc.toBoolean},
   toQuantity:   {fn: misc.toQuantity, arity: {0: [], 1: ["String"]}},
+  hasValue:     {fn: misc.hasValueFn},
   convertsToBoolean:    {fn: misc.createConvertsToFn(misc.toBoolean, 'boolean')},
   convertsToInteger:    {fn: misc.createConvertsToFn(misc.toInteger, 'number')},
   convertsToDecimal:    {fn: misc.createConvertsToFn(misc.toDecimal, 'number')},

--- a/src/misc.js
+++ b/src/misc.js
@@ -265,4 +265,15 @@ engine.singleton = function (coll, type) {
   throw new Error('Not supported type ' + type);
 };
 
+/**
+ * Checks whether a primitve value is present
+ */
+engine.hasValueFn = function(coll) {
+  return [isPrimitive(coll[0].data)];
+};
+
+function isPrimitive(data){
+  return data !== null && typeof data !== "object";
+}
+
 module.exports = engine;

--- a/src/misc.js
+++ b/src/misc.js
@@ -310,8 +310,7 @@ function isPrimitiveDefault(data){
     case 'string':
     case 'number':
     case 'boolean':
-    case 'symbol':
-    case 'bigint':
+    // case 'bigint':
       return true;
     default:
       return false;

--- a/src/misc.js
+++ b/src/misc.js
@@ -269,7 +269,11 @@ engine.singleton = function (coll, type) {
  * Checks whether a primitve value is present
  */
 engine.hasValueFn = function(coll) {
-  return [isPrimitive(coll[0].data)];
+  if (coll.length === 1){
+    return [isPrimitive(coll[0].data)];
+  } else {
+    return [false];
+  }
 };
 
 function isPrimitive(data){

--- a/src/misc.js
+++ b/src/misc.js
@@ -268,16 +268,54 @@ engine.singleton = function (coll, type) {
 /**
  * Checks whether a primitve value is present
  */
+const fhirPrimitives = new Set([
+  "instant",
+  "time",
+  "date",
+  "dateTime",
+  "base64Binary",
+  "decimal",
+  "integer64",
+  "boolean",
+  "string",
+  "code",
+  "markdown",
+  "id",
+  "integer",
+  "unsignedInt",
+  "positiveInt",
+  "uri",
+  "oid",
+  "uuid",
+  "canonical",
+  "url"
+]);
+
 engine.hasValueFn = function(coll) {
+  let model = this.model;
+
   if (coll.length === 1){
-    return [isPrimitive(coll[0].data)];
+    if(model){
+      return [fhirPrimitives.has(coll[0].path)];
+    } else {
+      return [isPrimitiveDefault(util.valData(coll[0]))];
+    }
   } else {
     return [false];
   }
 };
 
-function isPrimitive(data){
-  return data !== null && typeof data !== "object";
+function isPrimitiveDefault(data){
+  switch (typeof data){
+    case 'string':
+    case 'number':
+    case 'boolean':
+    case 'symbol':
+    case 'bigint':
+      return true;
+    default:
+      return false;
+  }
 }
 
 module.exports = engine;

--- a/src/navigation.js
+++ b/src/navigation.js
@@ -6,7 +6,6 @@ var engine = {};
 
 engine.children = function(coll){
   let model = this.model; // "this" is the context object
-
   return coll.reduce(function(acc, x){
     let d = util.valData(x);
     x = makeResNode(x);

--- a/test/cases/hasValue.yaml
+++ b/test/cases/hasValue.yaml
@@ -1,15 +1,63 @@
 tests:
-  - desc: 'collection only contains one string'
-    inputfile: patient-example.json
-    expression: Patient.name.given[0].hasValue()
-    result: [true]
+  - 'group: no model specified':
+    - desc: 'collection only contains one string'
+      inputfile: patient-example.json
+      expression: Patient.name.given[0].hasValue()
+      result: [true]
 
-  - desc: 'collection contains array of strings'
-    inputfile: patient-example.json
-    expression: Patient.name.given.hasValue()
-    result: [false]
+    - desc: 'collection contains array of strings'
+      inputfile: patient-example.json
+      expression: Patient.name.given.hasValue()
+      result: [false]
 
-  - desc: 'collection contains object'
-    inputfile: patient-example.json
-    expression: Patient.name.hasValue()
-    result: [false]
+    - desc: 'collection contains object'
+      inputfile: patient-example.json
+      expression: Patient.name.hasValue()
+      result: [false]
+      
+  - 'group: model specified':
+    - desc: 'collection only contains one string'
+      inputfile: patient-example.json
+      expression: Patient.name.given[0].hasValue()
+      model: 'r5'
+      result: [true]
+    - desc: 'collection contains array of strings'
+      inputfile: patient-example.json
+      expression: Patient.name.given.hasValue()
+      model: 'r5'
+      result: [false]
+
+    - desc: 'collection only contains one string'
+      inputfile: patient-example.json
+      expression: Patient.name.given[0].hasValue()
+      model: 'r4'
+      result: [true]
+    - desc: 'collection contains array of strings'
+      inputfile: patient-example.json
+      expression: Patient.name.given.hasValue()
+      model: 'r4'
+      result: [false]
+
+    - desc: 'collection only contains one string'
+      inputfile: patient-example.json
+      expression: Patient.name.given[0].hasValue()
+      model: 'stu3'
+      result: [true]
+    - desc: 'collection contains array of strings'
+      inputfile: patient-example.json
+      expression: Patient.name.given.hasValue()
+      model: 'stu3'
+      result: [false]
+
+    - desc: 'collection only contains one string'
+      inputfile: patient-example.json
+      expression: Patient.name.given[0].hasValue()
+      model: 'dstu2'
+      result: [true]
+    - desc: 'collection contains array of strings'
+      inputfile: patient-example.json
+      expression: Patient.name.given.hasValue()
+      model: 'dstu2'
+      result: [false]
+      
+

--- a/test/cases/hasValue.yaml
+++ b/test/cases/hasValue.yaml
@@ -1,0 +1,15 @@
+tests:
+  - desc: 'collection only contains one string'
+    inputfile: patient-example.json
+    expression: Patient.name.given[0].hasValue()
+    result: [true]
+
+  - desc: 'collection contains array of strings'
+    inputfile: patient-example.json
+    expression: Patient.name.given.hasValue()
+    result: [false]
+
+  - desc: 'collection contains object'
+    inputfile: patient-example.json
+    expression: Patient.name.hasValue()
+    result: [false]


### PR DESCRIPTION
The hasValue() method of the Fhirpath specification was not implemented (see also [issue ](https://github.com/HL7/fhirpath.js/issues/120). 

I added hasValue to the invocation table and provided an implementation in misc.js. The function basically checks if the content of the collection to be evaluated is a object or not.

The hasValue() method is integral to the constraints specified in StructureDefinitions. Without an implementation the evaluation of constraints with fhirpath.js is not possible.