### PR TITLE
Fix crash in `existsMacro` when running in strict mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "generateParser": "cd src/parser; rimraf ./generated/*; java -Xmx500M -cp \"../../antlr-4.9.3-complete.jar:$CLASSPATH\" org.antlr.v4.Tool -o generated -Dlanguage=JavaScript FHIRPath.g4; grunt updateParserRequirements",
     "build": "cd browser-build && webpack && rimraf fhirpath.zip && bestzip fhirpath.zip LICENSE.md fhirpath.min.js fhirpath.r5.min.js fhirpath.r4.min.js fhirpath.stu3.min.js fhirpath.dstu2.min.js && rimraf  LICENSE.md",
-    "test:unit": "jest && TZ=America/New_York jest && TZ=Europe/Paris jest",
+    "test:unit": "node --use_strict node_modules/.bin/jest && TZ=America/New_York node --use_strict node_modules/.bin/jest && TZ=Europe/Paris node --use_strict node_modules/.bin/jest",
     "test:unit:debug": "echo 'open chrome chrome://inspect/' && node --inspect node_modules/.bin/jest --runInBand",
     "build:demo": "npm run build && cd demo && npm run build",
     "test:e2e": "npm run build:demo && cypress run",

--- a/src/existence.js
+++ b/src/existence.js
@@ -17,7 +17,7 @@ engine.notFn = function(coll) {
 engine.existsMacro  = function(coll, expr) {
   var vec = coll;
   if (expr) {
-    return engine.existsMacro(whereMacro(coll, expr));
+    return engine.existsMacro(whereMacro.call(this, coll, expr));
   }
   return !util.isEmpty(vec);
 };


### PR DESCRIPTION
The implementation crashed in strict mode with `TypeError: Cannot set properties of undefined (setting '$index')`. It used `globalThis` for `this` in the call to `whereMacro` (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#no_this_substitution).