### PR TITLE
Read variables from context only when they are used in expression

### DIFF
--- a/test/api.test.js
+++ b/test/api.test.js
@@ -274,7 +274,7 @@ describe('evaluate type() on a FHIRPath evaluation result', () => {
 });
 
 describe('evaluate environment variables', () => {
-  it('variables can be immutable', () => {
+  it('context can be immutable', () => {
     const vars = Object.freeze({a: 'abc', b: 'def'});
     expect(fhirpath.evaluate(
       {},
@@ -283,7 +283,7 @@ describe('evaluate environment variables', () => {
     )).toStrictEqual([true]);
   })
 
-  it('variables can be immutable when new variables are defined', () => {
+  it('context can be immutable when new variables are defined', () => {
     const vars = Object.freeze({a: 'abc'});
     expect(fhirpath.evaluate(
       {},

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -287,9 +287,9 @@ describe('evaluate environment variables', () => {
     const vars = Object.freeze({a: 'abc'});
     expect(fhirpath.evaluate(
       {},
-      "defineVariable('b', '%a')",
+      "%a.defineVariable('b')",
       vars
-    )).toStrictEqual
+    )).toStrictEqual(['abc']);
   });
   it('variables are only read when needed', () => {
     const vars = {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -273,3 +273,33 @@ describe('evaluate type() on a FHIRPath evaluation result', () => {
   })
 });
 
+describe('evaluate environment variables', () => {
+  it('variables can be immutable', () => {
+    const vars = Object.freeze({a: 'abc', b: 'def'});
+    expect(fhirpath.evaluate(
+      {},
+      '%a = \'abc\'',
+      vars
+    )).toStrictEqual([true]);
+  })
+
+  it('variables can be immutable when new variables are defined', () => {
+    const vars = Object.freeze({a: 'abc'});
+    expect(fhirpath.evaluate(
+      {},
+      "defineVariable('b', '%a')",
+      vars
+    )).toStrictEqual
+  });
+  it('variables are only read when needed', () => {
+    const vars = {
+      get a() { return 'abc'; },
+      get b() { throw new Error('b should not be read'); }
+    };
+    expect(fhirpath.evaluate(
+      {},
+      '%a = \'abc\'',
+      vars
+    )).toStrictEqual([true]);
+  })
+});


### PR DESCRIPTION
This PR is a potential solution for #161 and ensures that variables in the context object can be evaluated lazily. This helps integrate fhirpath.js with libraries like Jotai, Angular Signals, or Solid.js. 

See also examples here [tiro-health.github.io/fhirpath-jotai/](https://tiro-health.github.io/fhirpath-jotai/)