### PR TITLE
Add ability to access the full path of returned content

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -1384,6 +1384,16 @@ class ResourceNode {
     return this.convertedData;
   }
 
+  /**
+   * The full property name of the node in the resource (e.g. Patient.name[0].given[0])
+   */
+  fullPropertyName() {
+    let result = this.parentResNode ? this.parentResNode.fullPropertyName() + '.' + this.propName : this.path;
+    if (this.index !== undefined) {
+      result += '[' + this.index + ']';
+    }
+    return result;
+  }
 }
 
 
@@ -1394,6 +1404,29 @@ class ResourceNode {
  */
 ResourceNode.makeResNode = function(data, parentResNode, path, _data, fhirNodeDataType, model) {
   return (data instanceof ResourceNode) ? data : new ResourceNode(data, parentResNode, path, _data, fhirNodeDataType, model);
+};
+
+/**
+ *  Returns a ResourceNode for the given data node, checking first to see if the
+ *  given node is already a ResourceNode.  Takes the same arguments as the
+ *  constructor for ResourceNode.
+ */
+ResourceNode.makeChildPropertyResNode = function(data, parentResNode, propName, path, _data, fhirNodeDataType, model) {
+  let result = (data instanceof ResourceNode) ? data : new ResourceNode(data, parentResNode, path, _data, fhirNodeDataType, model);
+  result.propName = propName;
+  return result;
+};
+
+/**
+ *  Returns a ResourceNode for the given data node, checking first to see if the
+ *  given node is already a ResourceNode.  Takes the same arguments as the
+ *  constructor for ResourceNode.
+ */
+ResourceNode.makeArrayChildPropertyResNode = function(data, parentResNode, propName, index, path, _data, fhirNodeDataType, model) {
+  let result = (data instanceof ResourceNode) ? data : new ResourceNode(data, parentResNode, path, _data, fhirNodeDataType, model);
+  result.propName = propName;
+  result.index = index;
+  return result;
 };
 
 // The set of available data types in the System namespace

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -195,20 +195,20 @@ util.makeChildResNodes = function(parentResNode, childProperty, model) {
   if (util.isSome(toAdd) || util.isSome(_toAdd)) {
     if(Array.isArray(toAdd)) {
       result = toAdd.map((x, i)=>
-        ResourceNode.makeResNode(x, parentResNode, childPath, _toAdd && _toAdd[i], fhirNodeDataType, model));
+        ResourceNode.makeArrayChildPropertyResNode(x, parentResNode, childProperty, i, childPath, _toAdd && _toAdd[i], fhirNodeDataType, model));
       // Add items to the end of the ResourceNode list that have no value
       // but have associated data, such as extensions or ids.
       const _toAddLength = _toAdd?.length || 0;
       for (let i = toAdd.length; i < _toAddLength; ++i) {
-        result.push(ResourceNode.makeResNode(null, parentResNode, childPath, _toAdd[i], fhirNodeDataType, model));
+        result.push(ResourceNode.makeArrayChildPropertyResNode(null, parentResNode, childProperty, i, childPath, _toAdd[i], fhirNodeDataType, model));
       }
     } else if (toAdd == null && Array.isArray(_toAdd)) {
       // Add items to the end of the ResourceNode list when there are no
       // values at all, but there is a list of associated data, such as
       // extensions or ids.
-      result = _toAdd.map((x) => ResourceNode.makeResNode(null, parentResNode, childPath, x, fhirNodeDataType, model));
+      result = _toAdd.map((x) => ResourceNode.makeChildPropertyResNode(null, parentResNode, childProperty, childPath, x, fhirNodeDataType, model));
     } else {
-      result = [ResourceNode.makeResNode(toAdd, parentResNode, childPath, _toAdd, fhirNodeDataType, model)];
+      result = [ResourceNode.makeChildPropertyResNode(toAdd, parentResNode, childProperty, childPath, _toAdd, fhirNodeDataType, model)];
     }
   } else {
     result = [];

--- a/test/fhirpath_propName.test.js
+++ b/test/fhirpath_propName.test.js
@@ -1,0 +1,172 @@
+/* eslint-disable linebreak-style */
+
+const fhirpath = require("../src/fhirpath");
+const fhirpath_r4_model = require("../fhir-context/r4");
+
+const testPatient = {
+  resourceType: "Patient",
+  name: [
+    {
+      family: "Doe",
+      given: ["John", "F"],
+    },
+    {
+      family: "Smith",
+      given: ["Jeremy"],
+    },
+  ],
+  contact: [
+    {
+      relationship: [
+        {
+          text: "Parent",
+        },
+      ],
+      name: {
+        family: "Jones",
+        given: ["John"],
+      },
+    },
+    {
+      relationship: [
+        {
+          _text: { id: "em1" },
+          text: "Emergency",
+        },
+      ],
+      name: {
+        family: "Smith",
+        given: ["Jane", "Francis"],
+      },
+    },
+  ],
+};
+
+test("traceProcessingHasAccessToPropertyNames", () => {
+  let fhirData = testPatient;
+  let environment = {
+    resource: fhirData,
+    rootResource: fhirData,
+  };
+
+  let output = [];
+  let tracefunction = function (x, label) {
+    if (Array.isArray(x)) {
+      for (let item of x) {
+        output.push(item);
+      }
+    } else {
+      output.push(x);
+    }
+    return x;
+  };
+
+  let options = {
+    traceFn: tracefunction,
+    async: false,
+  };
+
+  let result = fhirpath.evaluate(
+    fhirData,
+    "select(Patient.name.given.where($this = 'F') | Patient.name.family | Patient.contact.skip(1) | Patient.contact.relationship.text[1] | 'Brian').trace('output')",
+    environment,
+    fhirpath_r4_model,
+    options
+  );
+
+  for (const element of output) {
+    let node = element;
+    if (node.fullPropertyName)
+      console.log(node.fullPropertyName(), JSON.stringify(node.convertData()));
+  }
+
+  expect(result).toBeDefined();
+  expect(output).toBeDefined();
+  expect(output.length).toBe(6);
+  expect(output[0].fullPropertyName()).toBe("Patient.name[0].given[1]");
+  expect(output[1].fullPropertyName()).toBe("Patient.name[0].family");
+  expect(output[2].fullPropertyName()).toBe("Patient.name[1].family");
+  expect(output[3].fullPropertyName()).toBe("Patient.contact[1]");
+  expect(output[4].fullPropertyName()).toBe(
+    "Patient.contact[1].relationship[0].text"
+  );
+  expect(output[5]).toBe("Brian"); // which is not a ResourceNode
+});
+
+test("useContextFromExpressionResult", () => {
+  // This test will use the result of the expression as the context for the next expression.
+  const contextExpr = "contact.where(relationship.text = 'Emergency')"; // will return the name of the contact with the relationship text 'Emergency'.
+  const expression = "name.given"; // will return the given name(s) of the contact.
+
+  let fhirData = testPatient;
+  let environment = {
+    resource: fhirData,
+    rootResource: fhirData,
+  };
+
+  let output = [];
+  let traceFunction = function (x, label) {
+    if (label === "output_processing") {
+      if (Array.isArray(x)) {
+        for (let item of x) {
+          output.push(item);
+        }
+      } else {
+        output.push(x);
+      }
+    }
+    return x;
+  };
+
+  let options = {
+    traceFn: traceFunction,
+    async: false,
+  };
+
+  let result = fhirpath.evaluate(
+    fhirData,
+    "select(" + contextExpr + ").trace('output_processing')",
+    environment,
+    fhirpath_r4_model,
+    options
+  );
+
+  for (const element of output) {
+    let node = element;
+    if (node.fullPropertyName)
+      console.log(node.fullPropertyName(), JSON.stringify(node.convertData()));
+  }
+
+  expect(result).toBeDefined();
+  expect(output).toBeDefined();
+  expect(output.length).toBe(1);
+  expect(output[0].fullPropertyName()).toBe("Patient.contact[1]");
+  const contextNode = output[0];
+
+  // Second expression using the result of the first expression as context
+  output = []; // Reset output for the next expression
+  result = fhirpath.evaluate(
+    contextNode.convertData(), // Use the result of the first expression as context
+    {
+      base: contextNode.fullPropertyName(),
+      expression: "select("+expression+").trace('output_processing')"
+    },
+    environment,
+    fhirpath_r4_model,
+    options
+  );
+
+  for (const element of output) {
+    let node = element;
+    if (node.fullPropertyName)
+      console.log(node.fullPropertyName(), JSON.stringify(node.convertData()));
+  }
+
+  expect(result).toBeDefined();
+  expect(output).toBeDefined();
+  expect(output.length).toBe(2);
+  expect(output[0].fullPropertyName()).toBe("Patient.contact[1].name.given[0]");
+  expect(output[0].convertData()).toBe("Jane");
+  expect(output[1].fullPropertyName()).toBe("Patient.contact[1].name.given[1]");
+  expect(output[1].convertData()).toBe("Francis");
+});


### PR DESCRIPTION
Some use cases require access to the full path of a result item to be able to trace back to where it came from.
This is only applicable to non-mutated content direct from the resource.
i.e. Not results that are modified using things like split, merge, trim, addition etc.
But still work across things like `where` or `skip`

The ResourceNode has 2 new properties `propName` and `index` which are populated during navigation of the resource with the expression. (index only populated if the item is part of an array in the object)
And also a new function `fullPropertyName()` on the ResourceNode to traverse the parents assembling the full path.

Externally the only way to access this content is via the trace function (which is how I've tested it in the unit test).

The unit test shows how you can use these new properties effectively:
* To permit viewing where the output came from
* Using the output of one expression to pass content to a subsequent expression (without this the node position information is not available and therefore things like choice types or other complex type definitional things can't be processed)