### PR TITLE
Add a debug trace hook, and also some enhancements to the fhirpath parser to read position information.

### DIFF
--- a/src/fhirpath.d.ts
+++ b/src/fhirpath.d.ts
@@ -79,12 +79,74 @@ interface Model {
   };
 }
 
+interface ResourceNode {
+  /**
+   * The parent resource node
+   */
+  parentResNode: ResourceNode | null;
+  
+  /**
+   * The path of the node in the resource (e.g. Patient.name)
+   */
+  path: string | null;
+
+  /** 
+   * The index of the node in the array (e.g. The `0` in Patient.name[0])
+   */
+  index: number | undefined;
+  
+  propName: string | undefined;
+
+  /**
+   * The node's data or value (might be an object with sub-nodes, an array, or FHIR data type)
+   */
+  data: any;
+  
+  /**
+   * Additional data stored in a property named with "_" prepended
+   * See https://www.hl7.org/fhir/element.html#json for details
+   */
+  _data: Record<string, any>;
+  
+  /**
+   * FHIR node data type, if the resource node is described in the FHIR model
+   */
+  fhirNodeDataType: string | null;
+  
+  /**
+   * Cached converted data
+   */
+  convertData(): any;
+ 
+  /**
+   * The FHIR model used for this node
+   */
+  model : fhirpath.Model;
+ 
+  /**
+   * Retrieve any type information if available
+   */
+  getTypeInfo(): any;
+
+  /**
+   * Converts the node to its JSON representation
+   */
+  toJSON(): string;
+
+  /**
+   * Returns the full property name of the node where available
+   */
+  fullPropertyName(): string | undefined;
+}
+
+
 interface Options {
     resolveInternalTypes?: boolean
     traceFn?: (value: any, label: string) => void,
     userInvocationTable?: UserInvocationTable,
     terminologyUrl?: string,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    debugger?: (ctx: any, parentData: ResourceNode[], result: ResourceNode[], node: any) => void,
 }
 
 interface NoAsyncOptions extends Options {

--- a/src/fhirpath.js
+++ b/src/fhirpath.js
@@ -742,7 +742,11 @@ engine.doEval = function(ctx, parentData, node) {
 engine.doEvalSync = function(ctx, parentData, node) {
   const evaluator = engine.evalTable[node.type] || engine[node.type];
   if(evaluator){
-    return evaluator.call(engine, ctx, parentData, node);
+    let result = evaluator.call(engine, ctx, parentData, node);
+    if (ctx.debugger){
+      ctx.debugger(ctx, parentData, result, node);
+    }
+    return result;
   } else {
     throw new Error("No " + node.type + " evaluator ");
   }
@@ -803,6 +807,9 @@ function applyParsedPath(resource, parsedPath, envVars, model, options) {
   };
   if (options.traceFn) {
     ctx.customTraceFn = options.traceFn;
+  }
+  if (options.debugger) {
+    ctx.debugger = options.debugger;
   }
   if (options.userInvocationTable) {
     ctx.userInvocationTable = options.userInvocationTable;

--- a/src/navigation.js
+++ b/src/navigation.js
@@ -1,27 +1,36 @@
 const util = require("./utilities");
+const { ResourceNode } = require('./types');
 
 var engine = {};
 
 engine.children = function(coll){
   let model = this.model; // "this" is the context object
   return coll.reduce(function(acc, x){
-    let d = util.valData(x);
-    if (d == null) {
-      return acc;
-    } else if (typeof d === 'object') {
-      for (var prop of Object.keys(d)) {
-        util.pushFn(acc, util.makeChildResNodes(x, prop, model));
-      }
-      return acc;
-    } else {
+    if (!(x instanceof ResourceNode)) {
       return acc;
     }
+    if (typeof x.data === 'object' && x.data != null) {
+      let keys = Object.keys(x.data).filter( k => k !== 'resourceType');
+      for (let prop of keys) {
+        if (!prop.startsWith('_') || !keys.includes(prop.slice(1))) {
+          util.pushFn(acc, util.makeChildResNodes(x, prop, model));
+        }
+      }
+    }
+    else if (typeof x._data === 'object' && x._data != null) {
+      // remove any resourceType keys
+      let keys = Object.keys(x._data).filter( k => k !== 'resourceType');
+      for (let prop of keys) {
+        util.pushFn(acc, util.makeChildResNodes(x, prop, model));
+      }
+    }
+    return acc;
   }, []);
 };
 
 engine.descendants = function(coll){
-  var ch = engine.children.call(this, coll); // "this" is the context object
-  var res = [];
+  let ch = engine.children.call(this, coll); // "this" is the context object
+  let res = [];
   while(ch.length > 0){
     util.pushFn(res, ch);
     ch = engine.children.call(this, ch);

--- a/src/types.js
+++ b/src/types.js
@@ -1388,7 +1388,17 @@ class ResourceNode {
    * The full property name of the node in the resource (e.g. Patient.name[0].given[0])
    */
   fullPropertyName() {
-    let result = this.parentResNode ? this.parentResNode.fullPropertyName() + '.' + this.propName : this.path;
+    // check if the property name is for a primitive extension in FHIR
+    let propName = (this.propName?.startsWith('_') && this.model) ? this.propName.substring(1) : this.propName;
+
+    // Now Check if this is a choice type
+    if (this.parentResNode && this.model && this.fhirNodeDataType && propName.endsWith(this.fhirNodeDataType.charAt(0).toUpperCase() + this.fhirNodeDataType.substring(1))) {
+      if (this.model && this.model.choiceTypePaths[this.parentResNode?.path + '.' + propName.substring(0, propName.length - this.fhirNodeDataType.length)]) {
+        propName = propName.substring(0, propName.length - this.fhirNodeDataType.length);
+      }
+    }
+
+    let result = this.parentResNode ? this.parentResNode.fullPropertyName() + '.' + propName : this.path;
     if (this.index !== undefined) {
       result += '[' + this.index + ']';
     }

--- a/test/cases/5.8_tree_navigation.yaml
+++ b/test/cases/5.8_tree_navigation.yaml
@@ -12,7 +12,11 @@ tests:
     inputfile: patient-example-2.json
     model: r4
     expression: name.given.children()
-    result: []
+    result:
+      - Jacomus1Id
+      - { url: "http://hl7.org/fhir/StructureDefinition/display", valueString: "Jacomus1" }
+      - Jacomus2Id
+      - { url: "http://hl7.org/fhir/StructureDefinition/display", valueString: "Jacomus2" }
 
   - desc: '5.7.2. descendants() : collection'
 # Returns a collection with all descendant nodes of all items in the input collection. The result does not include the nodes in the input collection themselves. Is a shorthand for repeat(children()). Note that the ordering of the children is undefined and using operations like first() on the result may return different results on different platforms.
@@ -29,8 +33,15 @@ tests:
     inputfile: patient-example-2.json
     model: r4
     expression: name.given.descendants()
-    result: []
-
+    result: 
+      - Jacomus1Id
+      - { url: "http://hl7.org/fhir/StructureDefinition/display", valueString: "Jacomus1" }
+      - Jacomus2Id
+      - { url: "http://hl7.org/fhir/StructureDefinition/display", valueString: "Jacomus2" }
+      - "http://hl7.org/fhir/StructureDefinition/display"
+      - Jacomus1
+      - "http://hl7.org/fhir/StructureDefinition/display"
+      -  Jacomus2
 
 subject:
   desc:

--- a/test/fhirpath_propName.test.js
+++ b/test/fhirpath_propName.test.js
@@ -12,6 +12,15 @@ const testPatient = {
     },
     {
       family: "Smith",
+      _family: {
+        id: "smith-id",
+        extension: [
+          {
+            url: "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            valueString: "VV"
+          }
+        ]
+      },
       given: ["Jeremy"],
     },
   ],
@@ -169,4 +178,53 @@ test("useContextFromExpressionResult", () => {
   expect(output[0].convertData()).toBe("Jane");
   expect(output[1].fullPropertyName()).toBe("Patient.contact[1].name.given[1]");
   expect(output[1].convertData()).toBe("Francis");
+});
+
+test("traceProcessingHasAccessToPrimitiveExtensionPropertyNames", () => {
+  let fhirData = testPatient;
+  let environment = {
+    resource: fhirData,
+    rootResource: fhirData,
+  };
+
+  let output = [];
+  let tracefunction = function (x, label) {
+    if (Array.isArray(x)) {
+      for (let item of x) {
+        output.push(item);
+      }
+    } else {
+      output.push(x);
+    }
+    return x;
+  };
+
+  let options = {
+    traceFn: tracefunction,
+    async: false,
+  };
+
+  let result = fhirpath.evaluate(
+    fhirData,
+    "select(Patient.name.skip(1).first().descendants().trace('output'))",
+    environment,
+    fhirpath_r4_model,
+    options
+  );
+
+  for (const element of output) {
+    let node = element;
+    if (node.fullPropertyName)
+      console.log(node.fullPropertyName(), JSON.stringify(node.convertData()));
+  }
+
+  expect(result).toBeDefined();
+  expect(output).toBeDefined();
+  expect(output.length).toBe(6);
+  expect(output[0].fullPropertyName()).toBe("Patient.name[1].family");
+  expect(output[1].fullPropertyName()).toBe("Patient.name[1].given[0]");
+  expect(output[2].fullPropertyName()).toBe("Patient.name[1].family.id");
+  expect(output[3].fullPropertyName()).toBe("Patient.name[1].family.extension[0]");
+  expect(output[4].fullPropertyName()).toBe("Patient.name[1].family.extension[0].url");
+  expect(output[5].fullPropertyName()).toBe("Patient.name[1].family.extension[0].value");
 });


### PR DESCRIPTION
Sorry for building this on top of the other PR (with the children bug fixes...)

### Debugging Enhancements:
* [`src/fhirpath.js`](diffhunk://#diff-77b3f91094c45913357e000e85cec0cc626e61733d50e5d17767a97775c82609L745-R749): Added a debugging hook (`ctx.debugger`) to `engine.doEvalSync`, allowing custom debugging callbacks to inspect evaluation results. Also added support for passing a `debugger` option in `applyParsedPath` to enable debugging. [[1]](diffhunk://#diff-77b3f91094c45913357e000e85cec0cc626e61733d50e5d17767a97775c82609L745-R749) [[2]](diffhunk://#diff-77b3f91094c45913357e000e85cec0cc626e61733d50e5d17767a97775c82609R811-R813)

### Parsing Enhancements:
* [`src/parser/index.js`](diffhunk://#diff-539a4663a6f33a0b842b5687fe963007ebb75a6cbab64d95943d82321a355fbaR52): Added position information (line, column, and length) for various node types during parsing to improve traceability and debugging. [[1]](diffhunk://#diff-539a4663a6f33a0b842b5687fe963007ebb75a6cbab64d95943d82321a355fbaR52) [[2]](diffhunk://#diff-539a4663a6f33a0b842b5687fe963007ebb75a6cbab64d95943d82321a355fbaR61-R111)

Haven't done any unit tests yet, but have verified the changes using them in the fhirpath lab to work exactly how I was after.
Wanted to ensure this style of fix would be ok before continuing.
And I'll be doing more testing across various expressions with the lab to ensure there are no other issues.