### PR TITLE
Fix typing of httpHeaders option

### DIFF
--- a/src/fhirpath.d.ts
+++ b/src/fhirpath.d.ts
@@ -296,7 +296,7 @@ interface Options {
    * HTTP headers to use when making requests to FHIR servers. Keys are server
    * base URLs, values are objects mapping header names to header values.
    */
-  httpHeaders?: Record<string, string>;
+  httpHeaders?: Record<string, Record<string, string>>;
   /**
    * Whether to use precision-safe decimal arithmetic instead of native
    * JavaScript number arithmetic. Defaults to false.


### PR DESCRIPTION
Update the type of httpHeaders option to match documentation and implemenation