### PR TITLE
Fix crash when an environment variable is bound to an array of resource-shaped objects

### DIFF
--- a/src/fhirpath.js
+++ b/src/fhirpath.js
@@ -342,7 +342,7 @@ engine.ExternalConstantTerm = function(ctx, parentData, node) {
           ? makeResNode(i.__path__.ctx, i, i.__path__.parentResNode, i.__path__.path, null,
             i.__path__.fhirNodeDataType)
           : i?.resourceType
-            ? makeResNode(i.__path__.ctx, i, null, null, null, null)
+            ? makeResNode(ctx, i, null, null, null, null)
             : i );
     } else {
       value = value?.__path__

--- a/test/cases/8_variables.yaml
+++ b/test/cases/8_variables.yaml
@@ -41,6 +41,15 @@ tests:
       variables:
         "a.b() - 1": 5
       result: [2]
+    - desc: 'Variable bound to an array of resource-shaped objects'
+      expression: '%procedures.count()'
+      variables:
+        procedures:
+          - resourceType: Procedure
+            id: p1
+          - resourceType: Procedure
+            id: p2
+      result: [2]
 
 subject:
   n1: 1


### PR DESCRIPTION
Fixes #187

`ExternalConstantTerm`'s array branch used `i.__path__.ctx` in the `i?.resourceType` case, but `i.__path__` is undefined there by definition (that's the condition already checked above it) — so it threw instead of resolving the variable. Use the enclosing `ctx` parameter instead, matching the non-array branch just below and the `dataRoot` init elsewhere in this file.

```diff
-            ? makeResNode(i.__path__.ctx, i, null, null, null, null)
+            ? makeResNode(ctx, i, null, null, null, null)
```

Added a case to `test/cases/8_variables.yaml` covering a variable bound to an array of resource-shaped objects:

```yaml
    - desc: 'Variable bound to an array of resource-shaped objects'
      expression: '%procedures.count()'
      variables:
        procedures:
          - resourceType: Procedure
            id: p1
          - resourceType: Procedure
            id: p2
      result: [2]
```

